### PR TITLE
Fix Docker build cache for dind image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
           context: ${{ env.DIR_NAME }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta_dind.outputs.tags }}
-          cache-from: type=registry,ref=${{ fromJSON(steps.meta_base.outputs.json).tags[1] }}
+          cache-from: type=registry,ref=${{ fromJSON(steps.meta_dind.outputs.json).tags[1] }}
           cache-to: type=inline
           no-cache: ${{ github.event_name != 'pull_request' }}
           # Omit licenses label as there's no pratical way to get an accurate value for all the Ubuntu packages


### PR DESCRIPTION
Was using the wrong tag name.