### PR TITLE
Disable Starship container prompt info

### DIFF
--- a/devcontainer-base/config/starship.toml
+++ b/devcontainer-base/config/starship.toml
@@ -1,0 +1,2 @@
+[container]
+disabled = true


### PR DESCRIPTION
It was showing `systemd` rather than the container name.