### PR TITLE
Update README.md

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,6 @@ following:
 * https://github.com/bootandy/dust[Dust] a `du` alternative with easier to read output
 * https://github.com/b4b4r07/emoji-cli[emoji-cli] help writing emoji aliases
 * https://github.com/mrowa44/emojify[emojify] for converting emoji aliases to characters
-* https://github.com/zdharma/fast-syntax-highlighting[Fast Syntax Highlighting (F-Sy-H)] syntax highlighting for the command line
 * https://github.com/sharkdp/fd[fd] an easier to use `find` alternative
 * https://github.com/junegunn/fzf[fzf] a general-purpose command-line fuzzy finder
 * https://github.com/Aloxaf/fzf-tab[fzf-tab] use `fzf` for tab-completion
@@ -84,6 +83,7 @@ following:
 * https://github.com/ajeetdsouza/zoxide[zoxide] easily navigate to previous directories
 * https://github.com/zplug/zplug[zplug] for managing Zsh plugins (including Oh My Zsh)
 * https://github.com/zsh-users/zsh-autosuggestions[zsh-autosuggestions] suggests commands as you type based on history and completions
+* https://github.com/zsh-users/zsh-syntax-highlighting[zsh-syntax-highlighting] syntax highlighting for the command line
 
 === Running standalone
 

--- a/devcontainer-base/config/zsh/zplugrc.zsh
+++ b/devcontainer-base/config/zsh/zplugrc.zsh
@@ -58,7 +58,7 @@ zplug '/usr/local/share/zsh/plugins/starship', from:local, defer:1
 zplug '/usr/local/share/zsh/plugins/zoxide', from:local, defer:1
 zplug 'b4b4r07/emoji-cli', from:github, defer:1
 # fzf-tab must be loaded after fzf and ohmyzsh/lib/completion.zsh
-# defer 2 is after compinit, fzf-tab must be loaded after compinit and before fast-syntax-highlighting
+# defer 2 is after compinit, fzf-tab must be loaded after compinit and before zsh-syntax-highlighting
 zplug 'Aloxaf/fzf-tab', from:github, defer:2
 zplug 'MichaelAquilina/zsh-you-should-use', from:github, defer:1
 # use fixed version of plugins with few users/stars


### PR DESCRIPTION
`fast-syntax-highlighting` has been replaced by `zsh-syntax-highlighting`.